### PR TITLE
Endpoint /network/options never gives a response

### DIFF
--- a/src/controllers/network.ts
+++ b/src/controllers/network.ts
@@ -90,9 +90,7 @@ const getNetworkOptions = async (req: Request, res: Response, next: NextFunction
                 metadata: {}
             },
             allow: {
-                operation_statuses: [
-                    Object.values(OperationStatuses)
-                ],
+                operation_statuses: Object.values(OperationStatuses),
                 operation_types: [
                     OperationTypes.Transfer
                 ],

--- a/src/controllers/network.ts
+++ b/src/controllers/network.ts
@@ -73,7 +73,7 @@ const getNetworkOptions = async (req: Request, res: Response, next: NextFunction
         const errors = [];
 
         for (let item in ErrorCodes) {
-            if (!Number(item)) return;
+            if (!Number(item)) continue;
             errors.push({
                 code: Number(item),
                 message: ErrorCodes[item],

--- a/src/types/Operation.ts
+++ b/src/types/Operation.ts
@@ -12,7 +12,7 @@ export enum OperationStatusValues {
 
 export const OperationStatuses = {
     Success: {
-        value: OperationStatusValues.Success,
+        status: OperationStatusValues.Success,
         successful: true
     }
 }


### PR DESCRIPTION
In `for` loop through `ErrorCodes`, `continue` should be used instead of `return`.
Fix `operation_statuses` property in response.

_Tested against rosetta-cli v0.6.7_